### PR TITLE
Remove unused pending events field

### DIFF
--- a/src/timewarp/adapters/langgraph.py
+++ b/src/timewarp/adapters/langgraph.py
@@ -803,20 +803,17 @@ class LangGraphRecorder:
         if bs == 1:
             self.store.append_event(ev)
             return
-        if not hasattr(self, "__pending_list"):
-            setattr(self, "__pending_list", [])
-        pending: list[Event] = getattr(self, "__pending_list")
+        pending = self._pending_events
         pending.append(ev)
         if len(pending) >= bs:
             self.store.append_events(pending)
             pending.clear()
 
     def _flush_events(self) -> None:
-        if hasattr(self, "__pending_list"):
-            pending: list[Event] = getattr(self, "__pending_list")
-            if pending:
-                self.store.append_events(pending)
-                pending.clear()
+        pending = self._pending_events
+        if pending:
+            self.store.append_events(pending)
+            pending.clear()
 
     def _normalize_bytes(self, obj: Any) -> bytes:
         from ..codec import to_bytes


### PR DESCRIPTION
Use `_pending_events` for event batching in `LanggraphAdapter` to resolve an unused field and dynamic attribute inconsistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-45fd607f-3623-408e-87f2-1a3acbb54cc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45fd607f-3623-408e-87f2-1a3acbb54cc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

